### PR TITLE
[libaccounts-qt] Add 0001-Fix-GError-crash-under-Manager-account.patch

### DIFF
--- a/rpm/0004-Fix-GError-crash-under-Manager-account.patch
+++ b/rpm/0004-Fix-GError-crash-under-Manager-account.patch
@@ -1,0 +1,32 @@
+From 8da52d341a8fbb364c153377919cbfd0b0a88b1a Mon Sep 17 00:00:00 2001
+From: John Brooks <john.brooks@jollamobile.com>
+Date: Wed, 13 Nov 2013 14:22:25 -0700
+Subject: [PATCH] Fix GError crash under Manager::account
+
+It is possible for ag_manager_load_account to return NULL without setting error
+in the case of assertion failures. Avoid crashing in this case.
+---
+ Accounts/manager.cpp | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/Accounts/manager.cpp b/Accounts/manager.cpp
+index 448c925..a37a53b 100644
+--- a/Accounts/manager.cpp
++++ b/Accounts/manager.cpp
+@@ -253,10 +253,11 @@ Account *Manager::account(const AccountId &id) const
+         Account *tmp = new Account(account, const_cast<Manager*>(this));
+         g_object_unref(account);
+         return tmp;
+-    } else {
+-        Q_ASSERT(error != NULL);
++    } else if (error != NULL) {
+         d->lastError = Error(error);
+         g_error_free(error);
++    } else {
++        d->lastError = Error::Unknown;
+     }
+     return NULL;
+ }
+-- 
+1.8.3.1
+

--- a/rpm/libaccounts-qt.spec
+++ b/rpm/libaccounts-qt.spec
@@ -10,6 +10,7 @@ Patch0:         libaccounts-qt-1.2-disable-multilib.patch
 Patch1:         0001-libaccounts-qt-c++0x.patch
 Patch2:         0002-libaccounts-qt-documentation-path.patch 
 Patch3:         0003-Fix-test-service-MyService-to-include-messaging-tag.patch
+Patch4:         0004-Fix-GError-crash-under-Manager-account.patch
 BuildRequires:  doxygen
 BuildRequires:  fdupes
 BuildRequires:  pkgconfig(QtCore)
@@ -49,6 +50,7 @@ HTML documentation for the accounts.
 %patch1 -p1
 %patch2 -p1
 %patch3 -p1
+%patch4 -p1
 sed -i 's,DATA_PATH = .*,DATA_PATH = /opt/tests/%{name}/data,' tests/accountstest.pro
 sed -i 's,/usr/bin/accountstest,/opt/tests/%{name}/accountstest,' tests/tests.xml
 

--- a/rpm/libaccounts-qt5.spec
+++ b/rpm/libaccounts-qt5.spec
@@ -10,6 +10,7 @@ Patch0:         libaccounts-qt-1.2-disable-multilib.patch
 Patch1:         0001-libaccounts-qt-c++0x.patch
 Patch2:         0002-libaccounts-qt-documentation-path.patch
 Patch3:         0003-Fix-test-service-MyService-to-include-messaging-tag.patch
+Patch4:         0004-Fix-GError-crash-under-Manager-account.patch
 BuildRequires:  doxygen
 BuildRequires:  fdupes
 BuildRequires:  pkgconfig(Qt5Core)
@@ -51,6 +52,7 @@ HTML documentation for the accounts.
 %patch1 -p1
 %patch2 -p1
 %patch3 -p1
+%patch4 -p1
 sed -i 's,DATA_PATH = .*,DATA_PATH = /opt/tests/%{name}/data,' tests/accountstest.pro
 sed -i 's,/usr/bin/accountstest,/opt/tests/%{name}/accountstest,' tests/tests.xml
 


### PR DESCRIPTION
This crash has appeared in msyncd, after assertion failures like:

Nov 12 15:46:36 localhost invoker[968]: (process:967): accounts-glib-CRITICAL *_: ag_manager_load_account: assertion `account_id != 0' failed
Nov 12 15:46:36 localhost [967]: GLIB CRITICAL *_ accounts-glib - ag_manager_load_account: assertion `account_id != 0' failed

The cause of those is still unknown (and outside of libaccounts-qt), but we should be robust to them anyway.
