### PR TITLE
[libaccounts-qt] Fixed a few memory leaks

### DIFF
--- a/rpm/0004-Fix-memory-leaks.patch
+++ b/rpm/0004-Fix-memory-leaks.patch
@@ -1,0 +1,25 @@
+diff --git a/Accounts/account-service.cpp b/Accounts/account-service.cpp
+index 7317771..9b3a0cc 100644
+--- a/Accounts/account-service.cpp
++++ b/Accounts/account-service.cpp
+@@ -492,5 +492,7 @@ AuthData AccountService::authData() const
+ 
+     AgAuthData *agAuthData =
+         ag_account_service_get_auth_data(d->m_accountService);
+-    return AuthData(agAuthData);
++    AuthData authData(agAuthData);
++    ag_auth_data_unref(agAuthData);
++    return authData;
+ }
+diff --git a/Accounts/auth-data.cpp b/Accounts/auth-data.cpp
+index ef4b8d9..ed30396 100644
+--- a/Accounts/auth-data.cpp
++++ b/Accounts/auth-data.cpp
+@@ -109,6 +109,7 @@ QVariantMap AuthData::parameters() const
+     if (glibParameters == 0) return QVariantMap();
+ 
+     QVariant variant = gVariantToQVariant(glibParameters);
++    g_variant_unref(glibParameters);
+     if (!variant.isValid()) return QVariantMap();
+ 
+     return variant.toMap();

--- a/rpm/libaccounts-qt5.spec
+++ b/rpm/libaccounts-qt5.spec
@@ -10,6 +10,7 @@ Patch0:         libaccounts-qt-1.2-disable-multilib.patch
 Patch1:         0001-libaccounts-qt-c++0x.patch
 Patch2:         0002-libaccounts-qt-documentation-path.patch
 Patch3:         0003-Fix-test-service-MyService-to-include-messaging-tag.patch
+Patch4:         0004-Fix-memory-leaks.patch
 BuildRequires:  doxygen
 BuildRequires:  fdupes
 BuildRequires:  pkgconfig(Qt5Core)
@@ -51,6 +52,7 @@ HTML documentation for the accounts.
 %patch1 -p1
 %patch2 -p1
 %patch3 -p1
+%patch4 -p1
 sed -i 's,DATA_PATH = .*,DATA_PATH = /opt/tests/%{name}/data,' tests/accountstest.pro
 sed -i 's,/usr/bin/accountstest,/opt/tests/%{name}/accountstest,' tests/tests.xml
 


### PR DESCRIPTION
==5281==    at 0x4838AB0: malloc (vg_replace_malloc.c:270)
==5281==    by 0x6F41543: g_malloc (gmem.c:104)
==5281==    by 0x6F5DE1F: g_slice_alloc (gslice.c:1016)
==5281==    by 0x6F8801F: g_variant_new_from_children (gvariant-core.c:478)
==5281==    by 0x6F84CD3: g_variant_builder_end (gvariant.c:3654)
==5281==    by 0x6D0B543: ag_auth_data_get_login_parameters (ag-auth-data.c:383)
==5281==    by 0x4AF4383: Accounts::AuthData::parameters (auth-data.cpp:108)
==5281==    by 0x4A5238B: SSOSessionManager::createSsoIdentity (ssosessionmanager.cpp:154)
