### PR TITLE
Fix memory leak in gVariantToQVariantMap

### DIFF
--- a/rpm/0004-Fix-memory-leaks.patch
+++ b/rpm/0004-Fix-memory-leaks.patch
@@ -23,3 +23,23 @@ index ef4b8d9..ed30396 100644
      if (!variant.isValid()) return QVariantMap();
  
      return variant.toMap();
+diff --git a/Accounts/utils.cpp b/Accounts/utils.cpp
+index 71e24b6..5952e85 100644
+--- a/Accounts/utils.cpp
++++ b/Accounts/utils.cpp
+@@ -32,12 +32,14 @@ static QVariantMap gVariantToQVariantMap(GVariant *variant)
+ {
+     QVariantMap ret;
+     GVariantIter iter;
+-    const gchar *key;
++    gchar *key;
+     GVariant *value;
+ 
+     g_variant_iter_init (&iter, variant);
+     while (g_variant_iter_next (&iter, "{sv}", &key, &value)) {
+         ret.insert(UTF8(key), gVariantToQVariant(value));
++        g_variant_unref (value);
++        g_free (key);
+     }
+ 
+     return ret;


### PR DESCRIPTION
==26643== 78 bytes in 8 blocks are definitely lost in loss record 1,891 of 2,146
==26643==    at 0x4838AB0: malloc (vg_replace_malloc.c:270)
==26643==    by 0x6F45543: g_malloc (gmem.c:104)
==26643==    by 0x6F637DB: g_strdup (gstrfuncs.c:364)
==26643==    by 0x6F8A4AF: g_variant_valist_get (gvariant.c:4284)
==26643==    by 0x6F8A10F: g_variant_valist_get (gvariant.c:4670)
==26643==    by 0x6F8B89B: g_variant_iter_next (gvariant.c:5047)
==26643==    by 0x4AF80D7: Accounts::gVariantToQVariant(_GVariant*) (utils.cpp:39)
==26643==    by 0x4AF53EB: Accounts::AuthData::parameters() const (auth-data.cpp:111)
