### PR TITLE
[libaccounts-qt] Retarget upstream repo url. Contributes to MER#908

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libaccounts-qt"]
 	path = libaccounts-qt
-	url = https://code.google.com/p/accounts-sso.libaccounts-qt/
+	url = https://gitlab.com/accounts-sso/libaccounts-qt.git

--- a/rpm/libaccounts-qt5.spec
+++ b/rpm/libaccounts-qt5.spec
@@ -3,7 +3,7 @@ Version:        1.13
 Release:        1
 License:        LGPLv2.1
 Summary:        Accounts framework (Qt binding)
-Url:            https://code.google.com/p/accounts-sso.libaccounts-qt
+Url:            https://gitlab.com/accounts-sso/libaccounts-qt
 Group:          System/Libraries
 Source:         %{name}-%{version}.tar.bz2
 Patch0:         libaccounts-qt-1.2-disable-multilib.patch


### PR DESCRIPTION
The upstream repository url has changed from code.google.com to gitlab
due to the imminent closure of code.google.com.

Contributes to MER#908
