### PR TITLE
[libaccounts-qt5] Use gboolean instead of bool. Fixes JB#29340

### DIFF
--- a/rpm/0005-Use-gboolean-instead-of-bool.patch
+++ b/rpm/0005-Use-gboolean-instead-of-bool.patch
@@ -1,0 +1,34 @@
+From 4a33c4d33ec14e035b0f1f443f3fb52a70e0d07b Mon Sep 17 00:00:00 2001
+From: Mikko Harju <mikko.harju@jolla.com>
+Date: Thu, 13 Aug 2015 03:09:07 -0400
+Subject: [PATCH] Use gboolean instead of bool
+
+The "use-dbus" is a boolean g_object property, with actual type of
+gboolean, and gboolean is typedef int. g_object_get is a variadic
+function (no static type checking), and stores the queried value
+through pointer-to-int. If sizeof(bool) happens to be less than
+sizeof(int) and the stack variable useDBus is packed tightly,
+this can lead to stack corruption.
+
+Compiling the lib with -fstack-protector immediately pointed out
+the problem.
+---
+ Accounts/manager.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Accounts/manager.cpp b/Accounts/manager.cpp
+index 2eb077f..1ac78d0 100644
+--- a/Accounts/manager.cpp
++++ b/Accounts/manager.cpp
+@@ -530,7 +530,7 @@ bool Manager::abortOnTimeout() const
+  */
+ Manager::Options Manager::options() const
+ {
+-    bool useDBus = true;
++    gboolean useDBus = true;
+     g_object_get(d->m_manager,
+                  "use-dbus", &useDBus,
+                  NULL);
+-- 
+1.8.3-rc3
+

--- a/rpm/libaccounts-qt5.spec
+++ b/rpm/libaccounts-qt5.spec
@@ -11,6 +11,7 @@ Patch1:         0001-libaccounts-qt-c++0x.patch
 Patch2:         0002-libaccounts-qt-documentation-path.patch
 Patch3:         0003-Fix-test-service-MyService-to-include-messaging-tag.patch
 Patch4:         0004-Fix-memory-leaks.patch
+Patch5:         0005-Use-gboolean-instead-of-bool.patch
 BuildRequires:  doxygen
 BuildRequires:  fdupes
 BuildRequires:  pkgconfig(Qt5Core)
@@ -53,6 +54,7 @@ HTML documentation for the accounts.
 %patch2 -p1
 %patch3 -p1
 %patch4 -p1
+%patch5 -p1
 sed -i 's,DATA_PATH = .*,DATA_PATH = /opt/tests/%{name}/data,' tests/accountstest.pro
 sed -i 's,/usr/bin/accountstest,/opt/tests/%{name}/accountstest,' tests/tests.xml
 


### PR DESCRIPTION
Apparently sizeof(bool) != sizeof(gboolean), leading to stack
corruption.
